### PR TITLE
adding slack super powers to filter and webhook scripts

### DIFF
--- a/lambda-functions/jira-bot-filter-task-runner/.gitignore
+++ b/lambda-functions/jira-bot-filter-task-runner/.gitignore
@@ -1,5 +1,5 @@
 config.js
 *.zip
 node_modules
-package.json.personal
+package.json.live
 package.json.github

--- a/lambda-functions/jira-bot-filter-task-runner/config.js.txt
+++ b/lambda-functions/jira-bot-filter-task-runner/config.js.txt
@@ -9,6 +9,11 @@ module.exports = {
       password: process.env.password,
     },
   },
+  slack: {
+    api_token: process.env.slack_api_token,
+    bot_name: 'jira-filter-slack-bot',
+    bot_emoji: ':bear:',
+  },
   bots: ['xxx', 'yyy'], // Names of the bots
   transitionIds: {
     resolve: 5, // TransitionName -> corresponding jira transitionID
@@ -18,6 +23,8 @@ module.exports = {
     // Sample Task
     {
       filter: '', // valid jql query
+      expand: [], // list of jira fields to expand
+      fields: [], // list of jira fields to return
       conditions: [
          {
            type: 'lastHumanActivity', // No human activity since daysSince

--- a/lambda-functions/jira-bot-filter-task-runner/index.js
+++ b/lambda-functions/jira-bot-filter-task-runner/index.js
@@ -36,7 +36,10 @@ runTask = (Jira, startAt = 0) => {
           filteredIssues.forEach(IssueActions.updateIssue(Jira, task));
           filteredIssues.forEach(IssueTransitions.transitionIssue(Jira, task.transition));
 
-          SlackActions.run(Jira, task, filteredIssues);
+          // don't run slack actions if not needed
+          if (task.slack) {
+            SlackActions.run(Jira, task, filteredIssues);
+          }
 
           if (results.issues && results.total > results.issues.length + startAt) {
             console.log('running filter again to get more results');

--- a/lambda-functions/jira-bot-filter-task-runner/index.js
+++ b/lambda-functions/jira-bot-filter-task-runner/index.js
@@ -16,19 +16,23 @@ const done = (callback) => {
 
 runTask = (Jira, startAt = 0) => {
   return task => {
-    Jira.search.search(
-      {
+
+    const jiraOptions = {
         jql: task.filter,
         fields: task.fields || ['id', 'key', 'comment', 'priority', 'created'],
-        expand: task.expand || ['changelog'],
         maxResults: 100, // max is 100
         startAt: startAt
-      },
-      (err, results) => {
+    };
+
+    if (task.expand) {
+      jiraOptions.expand = task.expand;
+    }
+
+    Jira.search.search(jiraOptions, (err, results) => {
         if (err) {
           console.error('filter failed: %s\n', task.filter, err);
         } else if (results && results.issues && results.issues.length) {
-          console.log(`${results.issues.length} issues returned for [ ${task.filter} ]`);
+          console.log(`${results.issues.length} issues starting at ${startAt} returned for [ ${task.filter} ]`);
           const filteredIssues = results.issues.filter(
             ConditionChecker.checkConditions(task.conditions || [])
           );
@@ -42,7 +46,6 @@ runTask = (Jira, startAt = 0) => {
           }
 
           if (results.issues && results.total > results.issues.length + startAt) {
-            console.log('running filter again to get more results');
             runTask(Jira, results.issues.length + startAt)(task);
           }
         } else {

--- a/lambda-functions/jira-bot-filter-task-runner/index.js
+++ b/lambda-functions/jira-bot-filter-task-runner/index.js
@@ -41,7 +41,7 @@ runTask = (Jira, startAt = 0) => {
           filteredIssues.forEach(IssueTransitions.transitionIssue(Jira, task.transition));
 
           // don't run slack actions if not needed
-          if (task.slack) {
+          if (task.slack && filteredIssues && filteredIssues.length) {
             SlackActions.run(Jira, task, filteredIssues);
           }
 

--- a/lambda-functions/jira-bot-filter-task-runner/index.js
+++ b/lambda-functions/jira-bot-filter-task-runner/index.js
@@ -20,7 +20,7 @@ runTask = (Jira, startAt = 0) => {
     const jiraOptions = {
         jql: task.filter,
         fields: task.fields || ['id', 'key', 'comment', 'priority', 'created'],
-        maxResults: 100, // max is 100
+        maxResults: 50, // max is 100, but we have a changelog but when doing 100 -> https://jira.atlassian.com/browse/JRACLOUD-67458
         startAt: startAt
     };
 

--- a/lambda-functions/jira-bot-filter-task-runner/package.json
+++ b/lambda-functions/jira-bot-filter-task-runner/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "jira-connector": "^1.11.0",
+    "@slack/client": "^3.14.1",
+    "jira-connector": "^2.6.0",
     "moment": "^2.18.1"
   },
   "devDependencies": {

--- a/lambda-functions/jira-bot-filter-task-runner/slack-actions.js
+++ b/lambda-functions/jira-bot-filter-task-runner/slack-actions.js
@@ -88,5 +88,5 @@ const postToSlack = (task, users) => {
 
  
 exports.run = (Jira, task, issues) => {
-  getAllSlackUsers().then(users => issues.forEach(postToSlack(task, users)), console.log);
+  getAllSlackUsers().then(users => issues.forEach(postToSlack(task, users))).catch(console.log);
 }

--- a/lambda-functions/jira-bot-filter-task-runner/slack-actions.js
+++ b/lambda-functions/jira-bot-filter-task-runner/slack-actions.js
@@ -1,0 +1,91 @@
+const config = require('./config');
+const WebClient = require('@slack/client').WebClient;
+const web = new WebClient(config.slack.api_token);
+const slackUtils = require('./slack-utils');
+
+const findSlackUserName = (email, users) => {
+  for (let user of users) {
+    if (user.profile.email === email) {
+      return user.profile.display_name;
+    }
+  }
+}
+
+const applySlackActions = (issue, task, users) => {
+  for(let channel of task.slack.channel) {
+    if (channel[0] === '$') {
+      let username;
+
+      if (channel === '$jira.assignee') {
+        if (issue.fields.assignee) {
+          username = findSlackUserName(issue.fields.assignee.emailAddress, users);
+        } else {
+          username = findSlackUserName(issue.fields.reporter.emailAddress, users);
+        }
+      } else if (channel === '$jira.reporter') {
+        username = issue.fields.reporter.emailAddress;
+      }
+
+      if (username) {
+        channel = '@' + username;
+      } else {
+        break;
+      }
+
+    } else if (!(channel[0] === '#' || channel[0] === '@')) {
+      break;
+    }
+
+    const message = {
+      channel: channel,
+      text: task.slack.message,
+      options: {
+        reply_broadcast: true,
+        //thread_ts: '',
+        attachments: [slackUtils.jiraIssueToAttachment(issue, config.jira.host)],
+        username: config.slack.bot_name,
+        icon_emoji: `:${config.slack.bot_emoji}:`,
+      }
+    };
+
+    if (config.mode === 'dryrun') {
+      console.log(`would post slack message to ${channel}`)
+    } else {
+      web.chat.postMessage(message.channel, message.text, message.options, (error, res) => {
+        if (error) {
+          console.log('failed to post slack message: ', error);
+        } else {
+          console.log(`posted slack message to ${message.channel}`);
+        }
+      });
+    }
+  }
+};
+
+const getAllSlackUsers = () => {
+  return new Promise((resolve, reject) => { 
+    web.users.list({presence: false}, (error, res) => {
+      if (error) {
+        console.log('error', res);
+        reject(error);
+      } else {
+        resolve(res.members);
+      }
+    });
+  });
+}
+
+const postToSlack = (task, users) => {
+  return issue => {
+    if (!task.slack) {
+      return;
+    }
+
+    applySlackActions(issue, task, users);
+  };
+};
+
+ 
+exports.run = (Jira, task, issues) => {
+  getAllSlackUsers().then(users => issues.forEach(postToSlack(task, users)), console.log);
+}

--- a/lambda-functions/jira-bot-filter-task-runner/slack-actions.js
+++ b/lambda-functions/jira-bot-filter-task-runner/slack-actions.js
@@ -49,7 +49,8 @@ const applySlackActions = (issue, task, users) => {
     };
 
     if (config.mode === 'dryrun') {
-      console.log(`would post slack message to ${channel}`)
+      console.log(`Dry run enabled. Would post slack message to ${channel}`)
+      console.log(issue);
     } else {
       web.chat.postMessage(message.channel, message.text, message.options, (error, res) => {
         if (error) {

--- a/lambda-functions/jira-bot-filter-task-runner/slack-utils.js
+++ b/lambda-functions/jira-bot-filter-task-runner/slack-utils.js
@@ -16,7 +16,7 @@ const SlackUtils = {
         /Critical|Major/.test(issue.fields.priority.name) ? 'danger' : 'warning'
     }
 
-    if (!issues.fields.resolution && moment(moment.now()).isAfter(issue.fields.duedate)) {
+    if (!issue.fields.resolution && moment(moment.now()).isAfter(issue.fields.duedate)) {
       attachment.color = 'danger';
     }
 

--- a/lambda-functions/jira-bot-filter-task-runner/slack-utils.js
+++ b/lambda-functions/jira-bot-filter-task-runner/slack-utils.js
@@ -16,7 +16,7 @@ const SlackUtils = {
         /Critical|Major/.test(issue.fields.priority.name) ? 'danger' : 'warning'
     }
 
-    if (moment(moment.now()).isAfter(issue.fields.duedate)) {
+    if (!issues.fields.resolution && moment(moment.now()).isAfter(issue.fields.duedate)) {
       attachment.color = 'danger';
     }
 

--- a/lambda-functions/jira-bot-filter-task-runner/slack-utils.js
+++ b/lambda-functions/jira-bot-filter-task-runner/slack-utils.js
@@ -1,0 +1,43 @@
+const moment = require('moment');
+
+const SlackUtils = {
+
+  jiraIssueToAttachment: (issue, host, brief) => {
+    var attachment = {
+      "title": issue.fields.summary ? issue.key + ': ' + issue.fields.summary : issue.key,
+      "title_link": 'https://' + host + '/browse/' + issue.key,
+      "fallback": (issue.fields.summary || '') + 'https://' + host + '/browse/' + issue.key,
+      //"thumb_url": issue.fields.project.avatar,
+      //"pretext": "",
+    };
+
+    if (issue.fields.status && issue.fields.priority) {
+      attachment.color = /Done|Resolved|Closed/.test(issue.fields.status.name) ? 'good' : 
+        /Critical|Major/.test(issue.fields.priority.name) ? 'danger' : 'warning'
+    }
+
+    if (moment(moment.now()).isAfter(issue.fields.duedate)) {
+      attachment.color = 'danger';
+    }
+
+    if (!brief) {
+      attachment.text = issue.fields.description || '';
+      attachment.fields = [
+        {
+          "title": "Assignee",
+          "value": issue.fields.assignee ? issue.fields.assignee.displayName : 'Unassigned',
+          "short": true 
+        },
+        {
+          "title": "Status",
+          "value": issue.fields.status ? issue.fields.status.name : 'Open',
+          "short": true 
+        }
+      ]
+    };
+
+    return attachment;
+  }
+};
+
+module.exports = SlackUtils;

--- a/lambda-functions/jira-webhook-receiver/.gitignore
+++ b/lambda-functions/jira-webhook-receiver/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/lambda-functions/jira-webhook-receiver/.gitignore
+++ b/lambda-functions/jira-webhook-receiver/.gitignore
@@ -1,1 +1,3 @@
 config.js
+package.json.github
+package.json.live

--- a/lambda-functions/jira-webhook-receiver/config.js
+++ b/lambda-functions/jira-webhook-receiver/config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  jira: {
-    host: process.env.host,
-    basic_auth: {
-      username: process.env.username,
-      password: process.env.password,
-    }
-  }
-};

--- a/lambda-functions/jira-webhook-receiver/config.js.txt
+++ b/lambda-functions/jira-webhook-receiver/config.js.txt
@@ -1,0 +1,18 @@
+module.exports = {
+  jira: {
+    host: process.env.host,
+    basic_auth: {
+      username: process.env.username,
+      password: process.env.password,
+    },
+  },
+  slack: {
+    api_token: process.env.slack_api_token,
+    bot_name: 'jira-filter-slack-bot',
+    bot_emoji: ':bear:',
+  },
+  rules: {
+    resolutionExpression: /fixed|done/i,
+    resolutionChannel: '#jira-resolution'
+  }
+};

--- a/lambda-functions/jira-webhook-receiver/config.js.txt
+++ b/lambda-functions/jira-webhook-receiver/config.js.txt
@@ -14,5 +14,7 @@ module.exports = {
   rules: {
     resolutionExpression: /fixed|done/i,
     resolutionChannel: '#jira-resolution'
+    emptyComponentProjectExpression: /project5/i,
+    emptyComponentName: 'no-component',
   }
 };

--- a/lambda-functions/jira-webhook-receiver/index.js
+++ b/lambda-functions/jira-webhook-receiver/index.js
@@ -149,8 +149,8 @@ const editIssue = (issue) => {
       issueOptions.issue.fields['duedate'] = duedate(issue);
     }
 
-    if (/flex/i.test(issue.project.key) && (!issue.fields.components || issue.fields.components.length === 0)) {
-      issueOptions.issue.fields.components = [{name: 'not-sure'}];
+    if (config.rules.emptyComponentProjectExpression.test(issue.project.key) && (!issue.fields.components || issue.fields.components.length === 0)) {
+      issueOptions.issue.fields.components = [{name: config.rules.emptyComponentName}];
     }
 
     Jira.issue.editIssue(issueOptions, err => {

--- a/lambda-functions/jira-webhook-receiver/index.js
+++ b/lambda-functions/jira-webhook-receiver/index.js
@@ -161,7 +161,6 @@ const editIssue = (issue) => {
         console.log(`Successfully updated the issue ${issue.key}:`);
         resolve();
       }
-      //callback(null, { statusCode: 200, body: '' });
     });
   });
 }
@@ -181,7 +180,7 @@ exports.onReceive = (event, context, callback) => {
   console.log('ChangeLog', changelog);
 
   if (webhookEvent === 'issue_created' || webhookEvent === 'issue_updated') {
-    editIssue(issue).then(slackIssue(issue));
+    editIssue(issue).then(slackIssue(issue)).then(() => callback(null, { statusCode: 200, body: '' }), () => emptyReturn(callback));
   } else {
     return emptyReturn(callback);
   }

--- a/lambda-functions/jira-webhook-receiver/index.js
+++ b/lambda-functions/jira-webhook-receiver/index.js
@@ -206,5 +206,23 @@ exports.onReceive = (event, context, callback) => {
 }
 
 if (require.main === module) {
-  exports.onReceive({body:JSON.stringify({'issue_event_type_name': 'issue_updated', 'issue':{'key': 'flex-200', 'fields': {'project': {key: 'flex'}, 'priority': {name: 'Major'}, 'status': {name: 'Resolved'}, 'resolution': {name:'fixed'}, 'assignee': {name: 'leith'}}}})}, {}, console.log);
+  const issue = {
+    'key': 'project-200', 
+    'fields': {
+      'project': {key: 'project'}, 
+      'priority': {name: 'Major'}, 
+      'status': {name: 'Resolved'}, 
+      'resolution': {name:'fixed'}, 
+      'assignee': {name: 'leith'}
+    }
+  };
+
+  const changelog = {
+    items: [{
+      'field': 'resolution',
+      'toString': 'fixed',
+    }]
+  }
+
+  exports.onReceive({body:JSON.stringify({'issue_event_type_name': 'issue_updated', 'issue':issue, 'changelog':changelog})}, {}, console.log);
 }

--- a/lambda-functions/jira-webhook-receiver/package.json
+++ b/lambda-functions/jira-webhook-receiver/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "jira-connector": "^1.11.0",
+    "@slack/client": "^3.14.1",
+    "jira-connector": "^2.6.0",
     "moment": "^2.18.1"
   },
   "devDependencies": {},

--- a/lambda-functions/jira-webhook-receiver/package.json
+++ b/lambda-functions/jira-webhook-receiver/package.json
@@ -12,7 +12,12 @@
   "scripts": {},
   "author": "priyankc",
   "license": "Apache 2.0",
+  "config": {
+    "function_name": "jira-webhook-receiver",
+    "aws_region": "us-east-2"
+  },
   "scripts": {
-    "zip": "rm jiraWebhookReceiver.zip; zip -r jiraWebhookReceiver.zip ."
+    "zip": "rm $npm_package_config_function_name.zip; zip -r $npm_package_config_function_name.zip .",
+    "deploy": "aws lambda update-function-code --region $npm_package_config_aws_region --function-name $npm_package_config_function_name --zip-file fileb://$npm_package_config_function_name.zip"
   }
 }

--- a/lambda-functions/jira-webhook-receiver/slack-utils.js
+++ b/lambda-functions/jira-webhook-receiver/slack-utils.js
@@ -1,0 +1,43 @@
+const moment = require('moment');
+
+const SlackUtils = {
+
+  jiraIssueToAttachment: (issue, host, brief) => {
+    var attachment = {
+      "title": issue.fields.summary ? issue.key + ': ' + issue.fields.summary : issue.key,
+      "title_link": 'https://' + host + '/browse/' + issue.key,
+      "fallback": (issue.fields.summary || '') + 'https://' + host + '/browse/' + issue.key,
+      //"thumb_url": issue.fields.project.avatar,
+      //"pretext": "",
+    };
+
+    if (issue.fields.status && issue.fields.priority) {
+      attachment.color = /Done|Resolved|Closed/.test(issue.fields.status.name) ? 'good' : 
+        /Critical|Major/.test(issue.fields.priority.name) ? 'danger' : 'warning'
+    }
+
+    if (!issue.fields.resolution && moment(moment.now()).isAfter(issue.fields.duedate)) {
+      attachment.color = 'danger';
+    }
+
+    if (!brief) {
+      attachment.text = issue.fields.description || '';
+      attachment.fields = [
+        {
+          "title": "Assignee",
+          "value": issue.fields.assignee ? issue.fields.assignee.displayName : 'Unassigned',
+          "short": true 
+        },
+        {
+          "title": "Status",
+          "value": issue.fields.status ? issue.fields.status.name : 'Open',
+          "short": true 
+        }
+      ]
+    };
+
+    return attachment;
+  }
+};
+
+module.exports = SlackUtils;


### PR DESCRIPTION
for the jira bot filter:

- ability to post to slack for issues returned from filter
- ability to deal with more than 100 results (as results are limited to 100, not 1000)

for the jira webhook:

- post to slack issues based off changelog
- dryrun mode
