### PR TITLE
rework webhook receiver as a rules engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-(wip)
 # Intro
 emscripts is a bucket to organize all tools that would help EMs with their day to day jobs by either automating or enhancing the workflows. These tools could be one-off jobs that could respond to external webhooks or scheduled jobs.
 
@@ -17,6 +16,3 @@ These are scheduled scripts that need tighter integration with Google apps like 
 # Guidelines
 - Each tool is hosted and deployed independently of others
 - No code should be shared across each tool
-- If you have any questions
-  - talk to leith about slack bots
-  - talk to priyank about lambda functions and google scripts

--- a/lambda-functions/jira-webhook-receiver/.eslintrc.json
+++ b/lambda-functions/jira-webhook-receiver/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "airbnb-base"
+}

--- a/lambda-functions/jira-webhook-receiver/config.js.txt
+++ b/lambda-functions/jira-webhook-receiver/config.js.txt
@@ -1,4 +1,5 @@
 module.exports = {
+  // mode: 'dryrun',
   jira: {
     host: process.env.host,
     basic_auth: {
@@ -8,13 +9,33 @@ module.exports = {
   },
   slack: {
     api_token: process.env.slack_api_token,
-    bot_name: 'jira-filter-slack-bot',
-    bot_emoji: ':bear:',
   },
-  rules: {
-    resolutionExpression: /fixed|done/i,
-    resolutionChannel: '#jira-resolution'
-    emptyComponentProjectExpression: /project5/i,
-    emptyComponentName: 'no-component',
-  }
+  rules: [
+    // add as many rules as needed
+    {
+      description: 'a rule description for logging',
+      // rules match on conditions in if
+      // conditions can be a string, regex or a function with an issue passed in
+      if: {
+        event: /issue_created|issue_updated/,
+        issue: {
+          components: /componentx/,
+        },
+      },
+      // follow up actions can be to edit the issue or post to slack
+      then: {
+        edit: {
+          // values can be a string or a function with an issue passed in
+          components: [{ name: 'componenty' }],
+        },
+        slack: {
+          // values can be a string or a function with an issue passed in
+          channel: '#jira-rename',
+          message: 'i just renamed a component',
+          bot_name: 'fixie',
+          bot_emoji: 'bike',
+        },
+      },
+    },
+  ],
 };

--- a/lambda-functions/jira-webhook-receiver/config.js.txt
+++ b/lambda-functions/jira-webhook-receiver/config.js.txt
@@ -15,7 +15,7 @@ module.exports = {
     {
       description: 'a rule description for logging',
       // rules match on conditions in if
-      // conditions can be a string, regex or a function with an issue passed in
+      // conditions can be a string, regex or a boolean function with an issue passed in
       if: {
         event: /issue_created|issue_updated/,
         issue: {

--- a/lambda-functions/jira-webhook-receiver/index.js
+++ b/lambda-functions/jira-webhook-receiver/index.js
@@ -132,16 +132,16 @@ const filterIssue = (issueTest, issue, changelog) => {
   return test;
 };
 
-const filterChangelog = (changelogMatch, changelogValue, issue) => {
+const filterChangelog = (changelogRule, changelogValue, issue) => {
   let test = true;
 
   if (changelogValue && changelogValue.items) {
     changelogValue.items.forEach((change) => {
-      if (changelogMatch[change.field] !== null) {
+      if (changelogRule[change.field] !== null) {
         test = test &&
-          testRule(changelogMatch[change.field], change.toString, issue, changelogValue);
+          testRule(changelogRule[change.field], change.toString, issue, changelogValue);
         if (config.mode === 'dryrun') {
-          console.log(`testing change of ${change.field} to ${change.toString} against ${changelogMatch[change.field]} is ${test}`); // eslint-disable-line no-console
+          console.log(`testing change of ${change.field} to ${change.toString} against ${changelogRule[change.field]} is ${test}`); // eslint-disable-line no-console
         }
       }
     });

--- a/lambda-functions/jira-webhook-receiver/index.js
+++ b/lambda-functions/jira-webhook-receiver/index.js
@@ -108,8 +108,10 @@ const testIssue = (issueTest, issue) => {
           test = test &&
             (testMatch(issueTest[field], issue.fields[field].name, issue) ||
               testMatch(issueTest[field], issue.fields[field].key, issue));
-           console.log(`testing key or name for ${field} with ${issueTest[field]}`);
-           console.log(` and ${issue.fields[field].name} or ${issue.fields[field].key} and ${test} is results`);
+          if (config.mode === 'dryrun') {
+            console.log(`testing key or name for ${field} with ${issueTest[field]}`); // eslint-disable-line no-console
+            console.log(` and ${issue.fields[field].name} or ${issue.fields[field].key} and ${test} is results`); // eslint-disable-line no-console
+          }
         } else {
           // if value is an object we didn't expect, don't flag a match
           test = false;
@@ -130,7 +132,9 @@ const testChangelog = (changelogMatch, changelogValue, issue) => {
     changelogValue.items.forEach((change) => {
       if (changelogMatch[change.field] !== null) {
         test = test && testMatch(changelogMatch[change.field], change.toString, issue);
-        console.log(`testing change of ${change.field} to ${change.toString} against ${changelogMatch[change.field]} is ${test}`);
+        if (config.mode === 'dryrun') {
+          console.log(`testing change of ${change.field} to ${change.toString} against ${changelogMatch[change.field]} is ${test}`); // eslint-disable-line no-console
+        }
       }
     });
   }

--- a/lambda-functions/jira-webhook-receiver/index.js
+++ b/lambda-functions/jira-webhook-receiver/index.js
@@ -108,8 +108,8 @@ const testIssue = (issueTest, issue) => {
           test = test &&
             (testMatch(issueTest[field], issue.fields[field].name, issue) ||
               testMatch(issueTest[field], issue.fields[field].key, issue));
-          // console.log(`testing key or name for ${field} with ${issueTest[field]}
-          // and ${issue.fields[field].name} or ${issue.fields[field].key} and ${test} is results`);
+           console.log(`testing key or name for ${field} with ${issueTest[field]}`);
+           console.log(` and ${issue.fields[field].name} or ${issue.fields[field].key} and ${test} is results`);
         } else {
           // if value is an object we didn't expect, don't flag a match
           test = false;
@@ -130,10 +130,10 @@ const testChangelog = (changelogMatch, changelogValue, issue) => {
     changelogValue.items.forEach((change) => {
       if (changelogMatch[change.field] !== null) {
         test = test && testMatch(changelogMatch[change.field], change.toString, issue);
+        console.log(`testing change of ${change.field} to ${change.toString} against ${changelogMatch[change.field]} is ${test}`);
       }
     });
   }
-
   return test;
 };
 
@@ -167,8 +167,8 @@ exports.onReceive = (event, context, callback) => {
       if (test && rule.if.issue) {
         if (webhookEvent === 'issue_created' || webhookEvent === 'issue_moved') {
           test = testIssue(rule.if.issue, issue);
-        } else if (webhookEvent === 'issue_updated') {
-          test = testChangelog(rule.if.issue, changelog, issue);
+        } else {
+          test = testChangelog(rule.if.issue, changelog, issue) && testIssue(rule.if.issue, issue);
         }
       }
     }
@@ -222,15 +222,13 @@ if (require.main === module) {
           components: [],
         },
       },
-      /*
       changelog: {
         items: [{
           field: 'priority',
-          toString: 'Critical',
+          toString: 'Major (P3)',
         }],
       },
-      */
-      type: 'issue_created',
+      type: 'issue_updated',
     },
   ];
 

--- a/lambda-functions/jira-webhook-receiver/index.js
+++ b/lambda-functions/jira-webhook-receiver/index.js
@@ -1,227 +1,245 @@
-'use strict';
-
-const moment = require('moment');
 const JiraConnector = require('jira-connector');
 const config = require('./config');
 const slackUtils = require('./slack-utils');
-const WebClient = require('@slack/client').WebClient;
+const { WebClient } = require('@slack/client');
+
 const web = new WebClient(config.slack.api_token);
 
-const stakeholders_field = 'customfield_10700';
-const groups_watch_field = 'customfield_11000';
-const business_verticals_field = 'customfield_12200';
+const getValueOrNameFromArray = (array) => {
+  let values = [];
 
-const getStakeHolders = (issue) => {
-  const stakeHolderObjs = issue.fields[stakeholders_field] || [];
-  const stakeHolders = stakeHolderObjs.map(function(obj) {
-    return obj.value;
-  }) || [];
-  return stakeHolders;
-}
-
-const getBusinessVerticals = (issue) => {
-  const businessVerticalObjs = issue.fields[business_verticals_field] || [];
-  const businessVerticals = businessVerticalObjs.map(function(obj) {
-    return obj.value;
-  }) || [];
-  return businessVerticals;
-}
-
-const groupsThatShouldFollowIssue = (issue) => {
-  if (!issue) {
-    return [];
+  if (Array.isArray(array)) {
+    values = array.map(element => element.value || element.name);
   }
 
-  const stakeHolders = getStakeHolders(issue);
-  const businessVerticals = getBusinessVerticals(issue);
+  return values;
+};
 
-  const groups = [];
+const testMatch = (valueTest, value, original) => {
+  let test = true;
 
-  if (stakeHolders.length > 0) {
-    if (stakeHolders.includes('Learner')) {
-      groups.push({ name: 'LearnerServices' });
-    }
-    if (stakeHolders.includes('Enterprise Admins')) {
-      groups.push({ name: 'LearnerOps' });
-    }
-    if (stakeHolders.includes('Lite Agents (outsourced support)')) {
-      groups.push({ name: 'LearnerOps' });
-    }
-    if (stakeHolders.includes('Partner')) {
-      groups.push({ name: 'PartnerOps' });
-    }
-  }
-
-  if (businessVerticals.length > 0) {
-    if (businessVerticals.includes('Enterprise')) {
-      groups.push({ name: 'enterprise' });
-    }
-    if (businessVerticals.includes('Degrees')) {
-      groups.push({ name: 'DegreeOps' });
-    }
-  }
-
-  return groups.concat(issue.fields[groups_watch_field] || []);
-}
-
-const duedate = (issue) => {
-  const priority = issue.fields.priority && issue.fields.priority.name;
-  let numDaysDue = null;
-  switch (priority) {
-    case 'Minor (P3)':
-      numDaysDue = null;
-      break;
-    case 'Major (P2)':
-      numDaysDue = 30;
-      break;
-    case 'Critical (P1)':
-      numDaysDue = 7;
-      break;
-    case 'Blocker (P0)':
-      numDaysDue = 1;
-      break;
-  }
-  let duedate = null;
-  if (numDaysDue) {
-    duedate = moment().add(numDaysDue, 'days').format('YYYY-MM-DD');
-  }
-  console.log('Duedate: ', duedate);
-  return duedate;
-}
-
-const emptyReturn = (callback) => {
-  console.log('Returning without any OP');
-  callback(null, { statusCode: 200, body: 'Nothing to process' });
-}
-
-const allowDueDateUpdate = (changelog, webhookEvent) => {
-  let allowUpdate = false;
-  const latestChange = changelog.items.pop();
-  if (latestChange.field == 'priority' || webhookEvent == 'issue_created') {
-    console.log('Allow duedate update');
-    allowUpdate = true;
-  }
-  return allowUpdate;
-}
-
-const slackIssue = (issue, changelog, webhookEvent) => {
-  return new Promise((resolve, reject) => { 
-    let resolutionChange;
-
-    if (changelog && changelog.items) {
-      resolutionChange = changelog.items.find(item => item.field === 'resolution');
-    }
-
-    if (resolutionChange && config.rules.resolutionExpression.test(resolutionChange.toString)) {
-      const message = {
-        channel: config.rules.resolutionChannel,
-        text: 'awesome! @' + issue.fields.assignee.name + ' just marked an issue as ' + issue.fields.resolution.name,
-        options: {
-          reply_broadcast: true,
-          attachments: [slackUtils.jiraIssueToAttachment(issue, config.jira.host)],
-          username: config.slack.bot_name,
-          icon_emoji: `:${config.slack.bot_emoji}:`,
-        }
-      };
-
-      if (config.mode != 'dryrun') {
-        console.log('posting message to slack ', message);
-        web.chat.postMessage(message.channel, message.text, message.options, (error, res) => {
-          if (error) {
-            console.log('failed to post slack message: ', error);
-            reject(error);
-          } else {
-            console.log(`posted slack message to ${message.channel}`);
-            resolve();
-          }
-        });
-      } else {
-        console.log('dry run enabled. would have posted message to slack ', message);
-        resolve();
-      }
+  if (valueTest !== null) {
+    if (valueTest instanceof RegExp) {
+      test = valueTest.test(Array.isArray(value) ? value.join(',') : value);
+    } else if (valueTest instanceof Function) {
+      test = valueTest(original || value);
     } else {
-      resolve();
+      test = Array.isArray(value) ? value.some(v => v === valueTest) : valueTest === value;
     }
-  });
-}
-
-const editIssue = (issue, changelog, webhookEvent) => {
-  return new Promise((resolve, reject) => { 
-    const issueOptions = {
-      issueKey: issue.key,
-      issue: {
-        fields: {}
-      }
-    };
-    issueOptions.issue.fields[groups_watch_field] = groupsThatShouldFollowIssue(issue);
-
-    if (!changelog || allowDueDateUpdate(changelog, webhookEvent)) {
-      issueOptions.issue.fields['duedate'] = duedate(issue);
-    }
-
-    if (config.rules.emptyComponentProjectExpression.test(issue.fields.project.key) && (!issue.fields.components || issue.fields.components.length === 0)) {
-      issueOptions.issue.fields.components = [{name: config.rules.emptyComponentName}];
-    }
-
-    if (config.mode != 'dryrun') {
-      console.log('edited issue with ', issueOptions);
-      const Jira = new JiraConnector(config.jira);
-      Jira.issue.editIssue(issueOptions, err => {
-        if (err) {
-          console.log(`Error while update the issue ${issue.key}`, err);
-          reject(err);
-        } else {
-          console.log(`Successfully updated the issue ${issue.key}:`);
-          resolve();
-        }
-      });
-    } else {
-      console.log('dry run enabled. would have edited issue with ', issueOptions);
-      resolve();
-    }
-  });
-}
-
-exports.onReceive = (event, context, callback) => {
-  console.log('Lambda triggered');
-  const jiraData = JSON.parse(event.body);
-  const webhookEvent = jiraData['issue_event_type_name'];
-  const issue = jiraData && jiraData.issue;
-  const changelog = jiraData.changelog;
-
-  if (!issue) {
-    return emptyReturn(callback);
   }
 
-  console.log('Issue: ', issue);
-  console.log('ChangeLog', changelog);
-  console.log('webhookevent', webhookEvent);
+  return test;
+};
 
-  if (webhookEvent === 'issue_created' || webhookEvent === 'issue_updated' || webhookEvent === 'issue_resolved') {
-    editIssue(issue, changelog, webhookEvent).then(slackIssue(issue, changelog, webhookEvent)).then(() => callback(null, { statusCode: 200, body: '' }), (error) => { console.log(error); emptyReturn(callback); });
-  } else {
-    return emptyReturn(callback);
-  }
-}
-
-if (require.main === module) {
-  const issue = {
-    'key': 'project-200', 
-    'fields': {
-      'project': {key: 'project'}, 
-      'priority': {name: 'Major'}, 
-      'status': {name: 'Resolved'}, 
-      'resolution': {name:'fixed'}, 
-      'assignee': {name: 'leith'}
-    }
+const slackIssue = (slack, issue) => new Promise((resolve, reject) => {
+  const message = {
+    channel: (slack.channel instanceof Function) ? slack.channel(issue) : slack.channel,
+    text: (slack.message instanceof Function) ? slack.message(issue) : slack.message,
+    options: {
+      reply_broadcast: true,
+      attachments: [slackUtils.jiraIssueToAttachment(issue, config.jira.host)],
+      username: slack.bot_name || config.slack.bot_name,
+      icon_emoji: slack.bot_emoji ? `:${slack.bot_emoji}:` : `:${config.slack.bot_emoji}:`,
+    },
   };
 
-  const changelog = {
-    items: [{
-      'field': 'resolution',
-      'toString': 'fixed',
-    }]
+  if (config.mode !== 'dryrun') {
+    console.log('posting message to slack ', message); // eslint-disable-line no-console
+    web.chat.postMessage(message.channel, message.text, message.options, (error) => {
+      if (error) {
+        console.log('failed to post slack message: ', error); // eslint-disable-line no-console
+        reject(error);
+      } else {
+        console.log(`posted slack message to ${message.channel}`); // eslint-disable-line no-console
+        resolve();
+      }
+    });
+  } else {
+    console.log('dry run enabled. would have posted message to slack ', message, '\n'); // eslint-disable-line no-console
+    resolve();
+  }
+});
+
+const editIssue = (edits, issue, changelog, webhookEvent) => new Promise((resolve, reject) => {
+  const issueOptions = {
+    issueKey: issue.key,
+    issue: {
+      fields: {},
+    },
+  };
+
+  Object.keys(edits).forEach((edit) => {
+    if (edits[edit] instanceof Function) {
+      issueOptions.issue.fields[edit] = edits[edit](issue, changelog, webhookEvent);
+    } else {
+      issueOptions.issue.fields[edit] = edits[edit];
+    }
+  });
+
+  if (config.mode !== 'dryrun') {
+    console.log('edited issue with ', issueOptions); // eslint-disable-line no-console
+    const Jira = new JiraConnector(config.jira);
+    Jira.issue.editIssue(issueOptions, (err) => {
+      if (err) {
+        console.log(`Error while update the issue ${issue.key}`, err); // eslint-disable-line no-console
+        reject(err);
+      } else {
+        console.log(`Successfully updated the issue ${issue.key}:`); // eslint-disable-line no-console
+        resolve();
+      }
+    });
+  } else {
+    console.log('dry run enabled. would have edited issue with %j\n', issueOptions); // eslint-disable-line no-console
+    resolve();
+  }
+});
+
+const testIssue = (issueTest, issue) => {
+  let test = true;
+
+  if (issueTest) {
+    Object.keys(issueTest).forEach((field) => {
+      const value = issue.fields[field];
+      if (value !== null && value !== undefined) {
+        if (Array.isArray(value)) {
+          const flat = getValueOrNameFromArray(issue.fields[field]);
+          test = test && testMatch(issueTest[field], flat, issue);
+        } else if (value.key !== null || value.name !== null) {
+          test = test &&
+            (testMatch(issueTest[field], issue.fields[field].name, issue) ||
+              testMatch(issueTest[field], issue.fields[field].key, issue));
+          // console.log(`testing key or name for ${field} with ${issueTest[field]}
+          // and ${issue.fields[field].name} or ${issue.fields[field].key} and ${test} is results`);
+        } else {
+          // if value is an object we didn't expect, don't flag a match
+          test = false;
+        }
+      } else {
+        test = false;
+      }
+    });
   }
 
-  exports.onReceive({body:JSON.stringify({'issue_event_type_name': 'issue_updated', 'issue':issue, 'changelog':changelog})}, {}, console.log);
+  return test;
+};
+
+const testChangelog = (changelogMatch, changelogValue, issue) => {
+  let test = true;
+
+  if (changelogValue && changelogValue.items) {
+    changelogValue.items.forEach((change) => {
+      if (changelogMatch[change.field] !== null) {
+        test = test && testMatch(changelogMatch[change.field], change.toString, issue);
+      }
+    });
+  }
+
+  return test;
+};
+
+exports.onReceive = (event, context, callback) => {
+  const jiraData = JSON.parse(event.body);
+  const { changelog, issue, issue_event_type_name: webhookEvent } = jiraData;
+  const followup = { edit: [], slack: [] };
+
+  let promiseChain = Promise.resolve();
+
+  if (!issue) {
+    callback(null, { statusCode: 200, body: 'no issue found' });
+    return;
+  }
+
+  console.log('Issue: %j\n', issue); // eslint-disable-line no-console
+  console.log('webhookevent', webhookEvent, '\n'); // eslint-disable-line no-console
+
+  if (changelog) {
+    console.log('ChangeLog', changelog, '\n'); // eslint-disable-line no-console
+  }
+
+  (config.rules || []).forEach((rule) => {
+    let test = true;
+
+    if (rule.if !== null && rule.if.constructor === Object) {
+      if (test && rule.if.event) {
+        test = test && testMatch(rule.if.event, webhookEvent);
+      }
+
+      if (test && rule.if.issue) {
+        if (webhookEvent === 'issue_created' || webhookEvent === 'issue_moved') {
+          test = testIssue(rule.if.issue, issue);
+        } else if (webhookEvent === 'issue_updated') {
+          test = testChangelog(rule.if.issue, changelog, issue);
+        }
+      }
+    }
+
+    if (test) {
+      if (rule.then.edit) {
+        followup.edit.push(rule.then.edit);
+      }
+
+      if (rule.then.slack) {
+        followup.slack.push(rule.then.slack);
+      }
+    }
+
+    if (test) {
+      console.log(`rule passed for "${rule.description}"\n`); // eslint-disable-line no-console
+    } else if (config.mode === 'dryrun') {
+      console.log(`rule failed for "${rule.description}"\n`); // eslint-disable-line no-console
+    }
+  });
+
+  if (followup.edit.length > 0) {
+    const edits = followup.edit.reduce((x, y) => Object.assign(x, y));
+    promiseChain = promiseChain.then(editIssue(edits, issue, changelog, webhookEvent));
+  }
+
+  if (followup.slack.length > 0) {
+    followup.slack.forEach((slack) => {
+      promiseChain = promiseChain.then(slackIssue(slack, issue));
+    });
+  }
+
+  promiseChain.then(() => callback(null, { statusCode: 200, body: 'webhook ran without error' }), (error) => {
+    console.error(error); // eslint-disable-line no-console
+    callback(null, { statusCode: 200, body: 'webhook had an error' });
+  });
+};
+
+if (require.main === module) {
+  const jiraHooks = [
+    {
+      issue: {
+        fields: {
+          project: { key: 'PARTNER', name: 'team tickets' },
+          priority: { name: 'Major (P3)' },
+          // status: { name: 'Resolved' },
+          // resolution: { name: 'fixed' },
+          assignee: { name: 'clee', key: 'clee' },
+          // duedate: '2018-11-20',
+          issuetype: { name: 'Bug' },
+          components: [],
+        },
+      },
+      /*
+      changelog: {
+        items: [{
+          field: 'priority',
+          toString: 'Critical',
+        }],
+      },
+      */
+      type: 'issue_created',
+    },
+  ];
+
+  jiraHooks.forEach((jiraHook) => {
+    const json = JSON.stringify({
+      issue_event_type_name: jiraHook.type,
+      issue: jiraHook.issue,
+      changelog: jiraHook.changelog,
+    });
+    exports.onReceive({ body: json }, {}, () => {});
+  });
 }

--- a/lambda-functions/jira-webhook-receiver/package.json
+++ b/lambda-functions/jira-webhook-receiver/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {},
   "scripts": {},
-  "author": "priyankc",
+  "author": "priyankc, eleith",
   "license": "Apache 2.0",
   "config": {
     "function_name": "jira-webhook-receiver",

--- a/lambda-functions/jira-webhook-receiver/slack-utils.js
+++ b/lambda-functions/jira-webhook-receiver/slack-utils.js
@@ -2,42 +2,51 @@ const moment = require('moment');
 
 const SlackUtils = {
 
-  jiraIssueToAttachment: (issue, host, brief) => {
-    var attachment = {
-      "title": issue.fields.summary ? issue.key + ': ' + issue.fields.summary : issue.key,
-      "title_link": 'https://' + host + '/browse/' + issue.key,
-      "fallback": (issue.fields.summary || '') + 'https://' + host + '/browse/' + issue.key,
-      //"thumb_url": issue.fields.project.avatar,
-      //"pretext": "",
+  jiraIssueToAttachment: (issue, host, description, fields) => {
+    const attachment = {
+      title: issue.fields.summary ? issue.fields.summary : issue.key,
+      title_link: `https://${host}/browse/${issue.key}`,
+      fallback: `${(issue.fields.summary || '')} https://${host}/browse/${issue.key}`,
+      // "thumb_url": issue.fields.project.avatar,
+      // "pretext": "",
     };
 
     if (issue.fields.status && issue.fields.priority) {
-      attachment.color = /Done|Resolved|Closed/.test(issue.fields.status.name) ? 'good' : 
-        /Critical|Major/.test(issue.fields.priority.name) ? 'danger' : 'warning'
+      if (/Done|Resolved|Closed/.test(issue.fields.status.name)) {
+        attachment.color = 'good';
+      } else if (/Critical|Major|Blocker/.test(issue.fields.priority.name)) {
+        attachment.color = 'danger';
+      } else {
+        attachment.color = 'warning';
+      }
     }
 
     if (!issue.fields.resolution && moment(moment.now()).isAfter(issue.fields.duedate)) {
       attachment.color = 'danger';
     }
 
-    if (!brief) {
+    if (description) {
       attachment.text = issue.fields.description || '';
+    }
+
+    if (fields) {
       attachment.fields = [
         {
-          "title": "Assignee",
-          "value": issue.fields.assignee ? issue.fields.assignee.displayName : 'Unassigned',
-          "short": true 
+          title: 'Assignee',
+          value: issue.fields.assignee ? issue.fields.assignee.displayName : 'Unassigned',
+          short: true,
         },
         {
-          "title": "Status",
-          "value": issue.fields.status ? issue.fields.status.name : 'Open',
-          "short": true 
-        }
-      ]
-    };
+          title: 'Status',
+          value: issue.fields.status ? issue.fields.status.name : 'Open',
+          short: true,
+        },
+      ];
+    }
 
     return attachment;
-  }
+  },
+
 };
 
 module.exports = SlackUtils;


### PR DESCRIPTION
our config (not in this repo) contains all the specific rules we want for our own. this library is now left as a purely generic webhook reciever with more powerful options to edit and even slack on rule matches